### PR TITLE
Fix open issues url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,6 @@ This script will not tweet the fetched issues which are already exists in `db.js
 
 We are constantly working on improving this script and would love to get any types of contributions.
 If you have got any suggestions, drop your suggestion [here](https://github.com/arshadkazmi42/first-issues/issues/new).
-If you want to fix some existing bugs in the script, you can find open issues [here](https://github.com/arshadkamzi42/first-isues/issues)
+If you want to fix some existing bugs in the script, you can find open issues [here](https://github.com/arshadkazmi42/first-issues/issues)
 
 We are also working on building a contributing guide.


### PR DESCRIPTION
Resolving the broken url in contributing section of the README.md to go to the repo's open issues page.

https://github.com/arshadkazmi42/first-issues/issues/5