### PR TITLE
requirements: include requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tweepy
 Nose
-requests
+requests>=2.11.1
 click
 colorama


### PR DESCRIPTION
tweepy requires requests with version higher than 2.11.1
Include it in requirements to update requests version while installing

Didn't want to create a new issue just for this
