### PR TITLE
Add repo language hastags to tweet 

### DIFF
--- a/first_timers/first_timers.py
+++ b/first_timers/first_timers.py
@@ -49,7 +49,7 @@ def add_repo_languages(issues):
         elif res.ok:
             issue['languages'] = res.json()
         else:
-            raise RuntimeError('Could not handle response: ' + str(res) + ' from the API.')
+            warnings.warn('Could not handle response: ' + str(res) + ' from the API.')
     return issues
 
 

--- a/first_timers/first_timers.py
+++ b/first_timers/first_timers.py
@@ -38,6 +38,21 @@ def get_first_timer_issues():
     return items
 
 
+def add_repo_languages(issues):
+    """Adds the repo languages to the issues list."""
+    for issue in issues:
+        query_languages = issue['repository_url'] + '/languages'
+        res = requests.get(query_languages)
+        if res.status_code == 403:
+            warnings.warn('Rate limit reached getting languages')
+            return issues
+        elif res.ok:
+            issue['languages'] = res.json()
+        else:
+            raise RuntimeError('Could not handle response: ' + str(res) + ' from the API.')
+    return issues
+
+
 def get_fresh(old_issue_list, new_issue_list):
     """Returns which issues are not present in the old list of issues."""
     old_urls = set(x['url'] for x in old_issue_list)
@@ -73,6 +88,10 @@ def tweet_issues(issues, creds, debug=False):
     for issue in issues:
         # Not encoding here because Twitter treats code points as 1 character.
         title = issue['title']
+        language_hashTags = ''
+        if 'languages' in issue:
+            language_hashTags = ''.join(' #{}'.format(lang) for lang in issue['languages'])
+            hashTags = hashTags + language_hashTags
         if len(title) > allowed_title_len:
             title = title[:allowed_title_len - 1] + ellipse
 

--- a/first_timers/run.py
+++ b/first_timers/run.py
@@ -49,6 +49,7 @@ def run(only_save, db_path, create, creds_path, debug):
     # Getting the latest list of issues from GitHub
     new_issues = FT.get_first_timer_issues()
     fresh_issues = FT.get_fresh(old_issues, new_issues)
+    FT.add_repo_languages(fresh_issues)
     all_issues = fresh_issues + old_issues
 
     if not only_save:

--- a/first_timers/run.py
+++ b/first_timers/run.py
@@ -49,11 +49,12 @@ def run(only_save, db_path, create, creds_path, debug):
     # Getting the latest list of issues from GitHub
     new_issues = FT.get_first_timer_issues()
     fresh_issues = FT.get_fresh(old_issues, new_issues)
-    FT.add_repo_languages(fresh_issues)
     all_issues = fresh_issues + old_issues
 
     if not only_save:
         try:
+            FT.add_repo_languages(fresh_issues)
+
             if not os.path.exists(creds_path):
                 print('Credentials file does not exist.', file=sys.stdout)
                 sys.exit(-1)


### PR DESCRIPTION
Implement #52 

One thing to keep in mind is the Rate limit of Github API (for each new tweet there is a request for the repo language). According to the documentation `For unauthenticated requests, the rate limit allows for up to 60 requests per hour`

I don't see more than 60 tweets per hour so I think it'll be ok.