### PR TITLE
took only last n days of issues

### DIFF
--- a/first_timers/first_timers.py
+++ b/first_timers/first_timers.py
@@ -7,6 +7,8 @@ from datetime import datetime, timedelta
 import requests
 import tweepy
 
+DAYS_OLD = 15
+
 ellipse = u'…'
 query_string = 'https://api.github.com/search/issues?q=label:"{}"+is:issue+is:open&sort=updated&order=desc'
 queries = [query_string.format('good-first-issue'), query_string.format('good first issue')]
@@ -24,7 +26,7 @@ def humanize_url(api_url):
     return human_url_template.format(user=user, repo=repo, issue_num=issue_num)
 
 
-def get_first_timer_issues(daysold=15):
+def get_first_timer_issues(days_old=DAYS_OLD):
     """Fetches the first page of issues with the label first-timers-label which are still open."""
     items = []
     for query in queries:

--- a/first_timers/first_timers.py
+++ b/first_timers/first_timers.py
@@ -35,7 +35,7 @@ def get_first_timer_issues(days_old=DAYS_OLD):
             warnings.warn('Rate limit reached')
             return items
         elif res.ok:
-            [items.append(item) for item in res.json()['items'] if (datetime.now() - datetime.strptime(item['created_at'], "%Y-%m-%dT%H:%M:%SZ")).days < daysold]
+            [items.append(item) for item in res.json()['items'] if (datetime.now() - datetime.strptime(item['created_at'], "%Y-%m-%dT%H:%M:%SZ")).days < days_old]
         else:
             raise RuntimeError('Could not handle response: ' + str(res) + ' from the API.')
     return items

--- a/first_timers/first_timers.py
+++ b/first_timers/first_timers.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 import re
 import warnings
+from datetime import datetime, timedelta
 
 import requests
 import tweepy
@@ -23,7 +24,7 @@ def humanize_url(api_url):
     return human_url_template.format(user=user, repo=repo, issue_num=issue_num)
 
 
-def get_first_timer_issues():
+def get_first_timer_issues(daysold=15):
     """Fetches the first page of issues with the label first-timers-label which are still open."""
     items = []
     for query in queries:
@@ -32,7 +33,7 @@ def get_first_timer_issues():
             warnings.warn('Rate limit reached')
             return items
         elif res.ok:
-            items.extend(res.json()['items'])
+            [items.append(item) for item in res.json()['items'] if (datetime.now() - datetime.strptime(item['created_at'].split('T')[0].replace('-', '/') + ' ' + item['created_at'].split('T')[1].split('Z')[0], "%Y/%m/%d %H:%M:%S")).days < daysold]
         else:
             raise RuntimeError('Could not handle response: ' + str(res) + ' from the API.')
     return items

--- a/first_timers/first_timers.py
+++ b/first_timers/first_timers.py
@@ -33,7 +33,7 @@ def get_first_timer_issues(daysold=15):
             warnings.warn('Rate limit reached')
             return items
         elif res.ok:
-            [items.append(item) for item in res.json()['items'] if (datetime.now() - datetime.strptime(item["created_at"], "%Y-%m-%dT%H:%M:%SZ")).days < daysold]
+            [items.append(item) for item in res.json()['items'] if (datetime.now() - datetime.strptime(item['created_at'], "%Y-%m-%dT%H:%M:%SZ")).days < daysold]
         else:
             raise RuntimeError('Could not handle response: ' + str(res) + ' from the API.')
     return items

--- a/first_timers/first_timers.py
+++ b/first_timers/first_timers.py
@@ -33,7 +33,7 @@ def get_first_timer_issues(daysold=15):
             warnings.warn('Rate limit reached')
             return items
         elif res.ok:
-            [items.append(item) for item in res.json()['items'] if (datetime.now() - datetime.strptime(item['created_at'].split('T')[0].replace('-', '/') + ' ' + item['created_at'].split('T')[1].split('Z')[0], "%Y/%m/%d %H:%M:%S")).days < daysold]
+            [items.append(item) for item in res.json()['items'] if (datetime.now() - datetime.strptime(item["created_at"], "%Y-%m-%dT%H:%M:%SZ")).days < daysold]
         else:
             raise RuntimeError('Could not handle response: ' + str(res) + ' from the API.')
     return items


### PR DESCRIPTION
Fixes #51 

The `daysold` optional parameter has been added to `get_first_timer_issues` which by default takes in 15. This might be easily changed at the function definition (in `first_timers.py: line 27`); or even be passed in at the function call (in `run.py: line 50`) to override the default value.

Check everything which applies

- [x] I have added the issue number for which this pull request is created.

@arshadkazmi42 please review!


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#51: The fake new first issue](https://issuehunt.io/repos/163510179/issues/51)
---
</details>
<!-- /Issuehunt content-->