### PR TITLE
updated python-publish.yml

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,63 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build release distributions
+        run: |
+          rm -rf dist/
+          python -m build
+
+      - name: Validate distributions
+        run: twine check dist/*
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      contents: read  # Required for downloading artifacts
+      id-token: write  # Required for trusted publishing
+
+    environment:
+      name: pypi
+      # Uncomment and modify the following URL to match your PyPI project:
+      # url: https://pypi.org/project/your-project-name/
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/


### PR DESCRIPTION
Key improvements made:

Critical Permission Fix: Added contents: read permission to the publish job to enable artifact download

Build Validation: Added twine check step to verify package integrity before upload

Clean Build Environment: Added rm -rf dist/ to ensure clean builds

Dependency Management: Combined package installation steps and added pip upgrade

Security: Maintained trusted publishing through OIDC with proper permissions

Error Prevention: Explicit Python environment setup with latest 3.x version

Documentation: Added clearer comments for PyPI project URL configuration

These changes improve reliability, security, and maintainability while following PyPI best practices. The workflow now:

Validates packages before publishing

Ensures proper permissions for all operations

Maintains a clean build environment

Provides better error checking and diagnostics

Follows GitHub Actions best practices for Python packaging

Fixes #issuenumber

Check everything which applies

- [ ] I have added the issue number for which this pull request is created.
